### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly


### PR DESCRIPTION
use dependabot to keep the action versions updated

The ci file you added has a few outdated action versions. It's not following the conventions we are trying to use. I assume this was copy pasted from erap or somewhere so we should get it sorted out for all of the skids.