### PR TITLE
fix concurrency, function-level retry

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -92,6 +92,7 @@ jobs:
           environment_variables: STORAGE_BUCKET=${{secrets.STORAGE_BUCKET}}
           secrets: |
             /secrets/app/secrets.json=${{secrets.PROJECT_ID}}/skid-secrets
+          max_instance_count: 1
 
       - name: 📥 Create PubSub topic
         run: |
@@ -164,6 +165,7 @@ jobs:
           environment_variables: STORAGE_BUCKET=${{secrets.STORAGE_BUCKET}}
           secrets: |
             /secrets/app/secrets.json=${{secrets.PROJECT_ID}}/skid-secrets
+          max_instance_count: 1
 
       - name: 📥 Create PubSub topic
         run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -93,6 +93,7 @@ jobs:
           secrets: |
             /secrets/app/secrets.json=${{secrets.PROJECT_ID}}/skid-secrets
           max_instance_count: 1
+          event_trigger_retry: false
 
       - name: 📥 Create PubSub topic
         run: |
@@ -166,6 +167,7 @@ jobs:
           secrets: |
             /secrets/app/secrets.json=${{secrets.PROJECT_ID}}/skid-secrets
           max_instance_count: 1
+          event_trigger_retry: false
 
       - name: 📥 Create PubSub topic
         run: |


### PR DESCRIPTION
We only want one instance, and retries are handled within the function. Having GCP retry on failure can create an infinite loop if the failure is something that needs to be manually un-jammed. 