### PR TITLE
Include statewide numbers in county summary

### DIFF
--- a/src/wmrc/yearly.py
+++ b/src/wmrc/yearly.py
@@ -57,6 +57,10 @@ def county_summaries(year_df: pd.DataFrame, county_fields: list[str]) -> pd.Data
     counties_df["county_wide_msw_composted"] = composted_df.sum()
     counties_df["county_wide_msw_digested"] = digested_df.sum()
     counties_df["county_wide_msw_landfilled"] = landfilled_df.sum()
+    statewide = counties_df.sum()
+    statewide.name = "Statewide"
+    counties_df = pd.concat([counties_df, pd.DataFrame(statewide).T], axis=0)
+
     counties_df["county_wide_msw_diverted_total"] = (
         counties_df["county_wide_msw_recycled"]
         + counties_df["county_wide_msw_composted"]

--- a/src/wmrc/yearly.py
+++ b/src/wmrc/yearly.py
@@ -220,7 +220,7 @@ def statewide_metrics(county_year_df: pd.DataFrame) -> pd.DataFrame:
         pd.DataFrame: Statewide yearly metrics.
     """
 
-    in_state_only = county_year_df.drop(index="Out of State", errors="ignore")
+    in_state_only = county_year_df.drop(index=["Out of State", "Statewide"], errors="ignore")
 
     statewide_series = pd.Series()
     statewide_series["statewide_msw_recycled"] = in_state_only["county_wide_msw_recycled"].sum()

--- a/tests/test_yearly.py
+++ b/tests/test_yearly.py
@@ -20,14 +20,18 @@ class TestYearlyMetrics:
 
         expected_output = pd.DataFrame(
             {
-                "county_wide_msw_recycled": [7.5, 7.5],
-                "county_wide_msw_composted": [12.5, 12.5],
-                "county_wide_msw_digested": [2.5, 2.5],
-                "county_wide_msw_landfilled": [55.0, 55.0],
-                "county_wide_msw_diverted_total": [22.5, 22.5],
-                "county_wide_msw_recycling_rate": [22.5 / (22.5 + 55.0) * 100, 22.5 / (22.5 + 55.0) * 100],
+                "county_wide_msw_recycled": [7.5, 7.5, 15.0],
+                "county_wide_msw_composted": [12.5, 12.5, 25.0],
+                "county_wide_msw_digested": [2.5, 2.5, 5.0],
+                "county_wide_msw_landfilled": [55.0, 55.0, 110.0],
+                "county_wide_msw_diverted_total": [22.5, 22.5, 45.0],
+                "county_wide_msw_recycling_rate": [
+                    22.5 / (22.5 + 55.0) * 100,
+                    22.5 / (22.5 + 55.0) * 100,
+                    45.0 / (45.0 + 110.0) * 100,
+                ],
             },
-            index=["Cache_County__c", "Utah_County__c"],
+            index=["Cache_County__c", "Utah_County__c", "Statewide"],
         )
 
         output = yearly.county_summaries(facility_year_df, ["Cache_County__c", "Utah_County__c"])


### PR DESCRIPTION
It's a little redundant to have them both here and in the statewide metrics, but this is the only way to get them on the same graph as the county numbers on the dashboard. At the end of the day they're both calculated the same way so they should always be in sync.